### PR TITLE
Handle invokable controllers

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -19,7 +19,7 @@ class ControllerListener
     private $masterRequest = true;
 
     /**
-     * @var callable|null
+     * @var callable|object|null
      */
     private $calledController = null;
 
@@ -31,9 +31,7 @@ class ControllerListener
         }
         $this->masterRequest = false;
 
-        if (is_array($event->getController())) {
-            $this->calledController = $event->getController();
-        }
+        $this->calledController = $event->getController();
     }
 
     public function getCalledController(): ?callable

--- a/EventListener/MapperListener.php
+++ b/EventListener/MapperListener.php
@@ -91,13 +91,19 @@ class MapperListener
     }
 
     /**
-     * @param callable $controller
-     * @return null|Dto\View
+     * @param mixed $controller
+     * @return Dto\View|null
+     * @throws \ReflectionException
      */
-    private function getViewAnnotationByController(callable $controller): ?Dto\View
+    private function getViewAnnotationByController($controller): ?Dto\View
     {
         /** @var Controller $controllerObject */
-        list($controllerObject, $methodName) = $controller;
+        if (is_array($controller)) {
+            list($controllerObject, $methodName) = $controller;
+        } else {
+            $controllerObject = $controller;
+            $methodName = '__invoke';
+        }
 
         $controllerReflectionObject = new \ReflectionObject($controllerObject);
         $reflectionMethod = $controllerReflectionObject->getMethod($methodName);


### PR DESCRIPTION
In case of SOLID controllers, controller may have only one method. If such a controller has only one method named "__invoke", `FilterControllerEvent->getController` returns controller object instead of callable array. In that case getting controllerObject and methodName is slightly different.